### PR TITLE
Make sure asclen is at least 1

### DIFF
--- a/src/libjasper/base/jas_icc.c
+++ b/src/libjasper/base/jas_icc.c
@@ -1104,6 +1104,8 @@ static int jas_icctxtdesc_input(jas_iccattrval_t *attrval, jas_stream_t *in,
 	if (jas_stream_read(in, txtdesc->ascdata, txtdesc->asclen) !=
 	  JAS_CAST(int, txtdesc->asclen))
 		goto error;
+	if (txtdesc->asclen < 1)
+		goto error;
 	txtdesc->ascdata[txtdesc->asclen - 1] = '\0';
 	if (jas_iccgetuint32(in, &txtdesc->uclangcode) ||
 	  jas_iccgetuint32(in, &txtdesc->uclen))


### PR DESCRIPTION
If txtdesc->asclen is < 1, the array index of txtdesc->ascdata will be negative which causes the heap based overflow.

Regards CVE-2018-19540.
Regards https://github.com/mdadams/jasper/issues/182 bug#3
Fix by Markus Koschany <apo@debian.org>.
From https://gist.github.com/apoleon/13598a45bf6522f6a79b77a629205823