### PR TITLE
Fix CVE-2018-19542: Check for NULL pointer in jp2_decode

### DIFF
--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -388,6 +388,9 @@ jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr)
 				jas_image_setcmpttype(dec->image, newcmptno, jp2_getct(jas_image_clrspc(dec->image), 0, channo + 1));
 				}
 #endif
+			} else {
+				jas_eprintf("error: invalid MTYP in CMAP box\n");
+				goto error;
 			}
 		}
 	}


### PR DESCRIPTION
Proper fix instead of #182 and #197.
[bug-19542.jp2.zip](https://github.com/mdadams/jasper/files/2976367/bug-19542.jp2.zip)

