### PR TITLE
Fix integer width in jpc_math

### DIFF
--- a/src/libjasper/jpc/jpc_math.c
+++ b/src/libjasper/jpc/jpc_math.c
@@ -86,7 +86,7 @@
 
 /* Calculate the integer quantity floor(log2(x)), where x is a positive
   integer. */
-int jpc_floorlog2(int x)
+int jpc_floorlog2(int_fast32_t x)
 {
 	int y;
 
@@ -105,7 +105,7 @@ int jpc_floorlog2(int x)
   integer. */
 /* This function is the basically the same as ceillog2(x), except that the
   allowable range for x is slightly different. */
-int jpc_firstone(int x)
+int jpc_firstone(int_fast32_t x)
 {
 	int n;
 

--- a/src/libjasper/jpc/jpc_math.h
+++ b/src/libjasper/jpc/jpc_math.h
@@ -67,6 +67,7 @@
 \******************************************************************************/
 
 #include	<assert.h>
+#include	<stdint.h>
 
 /******************************************************************************\
 * Macros
@@ -90,10 +91,10 @@
 
 /* Calculate the bit position of the first leading one in a nonnegative
   integer. */
-int jpc_firstone(int x);
+int jpc_firstone(int_fast32_t x);
 
 /* Calculate the integer quantity floor(log2(x)), where x is a positive
   integer. */
-int jpc_floorlog2(int x);
+int jpc_floorlog2(int_fast32_t x);
 
 #endif


### PR DESCRIPTION
Fix denial of service via a reachable assertion in the function jpc_firstone in libjasper/jpc/jpc_math.c.

Assigned CVE-2018-9055.
Fixes https://github.com/mdadams/jasper/issues/172.

Fix by Fridrich Strba <FStrba@suse.com>.