### PR TITLE
Add -I<include_dir> to support users that use #include <jasper/jasper.h>

### DIFF
--- a/build/jasper.pc.in
+++ b/build/jasper.pc.in
@@ -6,4 +6,4 @@ Description: Image Processing/Coding Tool Kit with JPEG-2000 Support
 Version: @JAS_VERSION@
 
 Libs: -L${libdir} -ljasper
-Cflags: -I${includedir}/jasper
+Cflags: -I${includedir}/jasper -I${includedir}


### PR DESCRIPTION
For example, GEGL (gegl.org) uses that style of include.