### PR TITLE
Fix incorrect checking of the EPH marker

### DIFF
--- a/src/libjasper/jpc/jpc_t2dec.c
+++ b/src/libjasper/jpc/jpc_t2dec.c
@@ -365,18 +365,16 @@ hdroffstart = jas_stream_getrwcount(pkthdrstream);
 	}
 
 	if (cp->csty & JPC_COD_EPH) {
-		if (jpc_dec_lookahead(pkthdrstream) == JPC_MS_EPH) {
-			if (!(ms = jpc_getms(pkthdrstream, dec->cstate))) {
-				jas_eprintf("cannot get (EPH) marker segment\n");
-				return -1;
-			}
-			if (jpc_ms_gettype(ms) != JPC_MS_EPH) {
-				jpc_ms_destroy(ms);
-				jas_eprintf("missing EPH marker segment\n");
-				return -1;
-			}
-			jpc_ms_destroy(ms);
+		if (!(ms = jpc_getms(pkthdrstream, dec->cstate))) {
+			jas_eprintf("cannot get (EPH) marker segment\n");
+			return -1;
 		}
+		if (jpc_ms_gettype(ms) != JPC_MS_EPH) {
+			jpc_ms_destroy(ms);
+			jas_eprintf("missing EPH marker segment\n");
+			return -1;
+		}
+		jpc_ms_destroy(ms);
 	}
 
 	/* decode the packet body. */


### PR DESCRIPTION
## Corresponding issue
resolve #225

### Why
JasPer assumes that there is no successive two bytes out of the range
from 0xff80 to 0xffff in a bitstream. This assumption prevents the
decoder from correct checking the existence of EPH marker (0xff92) when the
third LSB of the Scod parameter is "1".

### How
Delete the assumption from the code lines.