### PR TITLE
Fix wrong checking EPH marker

### DIFF
--- a/src/libjasper/jpc/jpc_t2dec.c
+++ b/src/libjasper/jpc/jpc_t2dec.c
@@ -366,18 +366,16 @@ static int jpc_dec_decodepkt(jpc_dec_t *dec, jas_stream_t *pkthdrstream, jas_str
 	}
 
 	if (cp->csty & JPC_COD_EPH) {
-		if (jpc_dec_lookahead(pkthdrstream) == JPC_MS_EPH) {
-			if (!(ms = jpc_getms(pkthdrstream, dec->cstate))) {
-				jas_eprintf("cannot get (EPH) marker segment\n");
-				return -1;
-			}
-			if (jpc_ms_gettype(ms) != JPC_MS_EPH) {
-				jpc_ms_destroy(ms);
-				jas_eprintf("missing EPH marker segment\n");
-				return -1;
-			}
-			jpc_ms_destroy(ms);
+		if (!(ms = jpc_getms(pkthdrstream, dec->cstate))) {
+			jas_eprintf("cannot get (EPH) marker segment\n");
+			return -1;
 		}
+		if (jpc_ms_gettype(ms) != JPC_MS_EPH) {
+			jpc_ms_destroy(ms);
+			jas_eprintf("missing EPH marker segment\n");
+			return -1;
+		}
+		jpc_ms_destroy(ms);
 	}
 
 	/* decode the packet body. */


### PR DESCRIPTION
**Why**: If EPH markers are required (by setting the third LSB of Scod parameter to "1" in the COD marker segment, see A.6.1), each packet header in any given tile-part shall be postpended with an EPH marker segment. jpc_dec_lookahead() never returns a value out of the range from 0xff80 to 0xffff, however, a broken bitstream may have a value in this range. Therefore, `if (jpc_dec_lookahead(pkthdrstream) == JPC_MS_EPH)` cannot check the case that the packet header has not been correctly postpended with an EPH marker (= 0xff92).
**How**: Delete https://github.com/jasper-software/jasper/blob/9580dcb0b40a8ebe1bd45976235f2f518d0adc0b/src/libjasper/jpc/jpc_t2dec.c#L369 and corresponding https://github.com/jasper-software/jasper/blob/9580dcb0b40a8ebe1bd45976235f2f518d0adc0b/src/libjasper/jpc/jpc_t2dec.c#L380.