### PR TITLE
Bulk I/O optimizations for jas_stream

### DIFF
--- a/src/libjasper/base/jas_debug.c
+++ b/src/libjasper/base/jas_debug.c
@@ -118,12 +118,11 @@ int jas_eprintf(const char *fmt, ...)
 }
 
 /* Dump memory to a stream. */
-int jas_memdump(FILE *out, void *data, size_t len)
+int jas_memdump(FILE *out, const void *data, size_t len)
 {
 	size_t i;
 	size_t j;
-	jas_uchar *dp;
-	dp = data;
+	const jas_uchar *dp = data;
 	for (i = 0; i < len; i += 16) {
 		fprintf(out, "%04zx:", i);
 		for (j = 0; j < 16; ++j) {

--- a/src/libjasper/base/jas_icc.c
+++ b/src/libjasper/base/jas_icc.c
@@ -1074,7 +1074,7 @@ static int jas_icctxtdesc_input(jas_iccattrval_t *attrval, jas_stream_t *in,
 	if (!(txtdesc->ascdata = jas_malloc(txtdesc->asclen)))
 		goto error;
 	if (jas_stream_read(in, txtdesc->ascdata, txtdesc->asclen) !=
-	  JAS_CAST(int, txtdesc->asclen))
+	  txtdesc->asclen)
 		goto error;
 	txtdesc->ascdata[txtdesc->asclen - 1] = '\0';
 	if (jas_iccgetuint32(in, &txtdesc->uclangcode) ||
@@ -1083,7 +1083,7 @@ static int jas_icctxtdesc_input(jas_iccattrval_t *attrval, jas_stream_t *in,
 	if (!(txtdesc->ucdata = jas_alloc2(txtdesc->uclen, 2)))
 		goto error;
 	if (jas_stream_read(in, txtdesc->ucdata, txtdesc->uclen * 2) !=
-	  JAS_CAST(int, txtdesc->uclen * 2))
+	  txtdesc->uclen * 2)
 		goto error;
 	if (jas_iccgetuint16(in, &txtdesc->sccode))
 		goto error;
@@ -1127,7 +1127,7 @@ static int jas_icctxtdesc_output(jas_iccattrval_t *attrval, jas_stream_t *out)
 	  jas_stream_putc(out, 0) == EOF ||
 	  jas_iccputuint32(out, txtdesc->uclangcode) ||
 	  jas_iccputuint32(out, txtdesc->uclen) ||
-	  jas_stream_write(out, txtdesc->ucdata, txtdesc->uclen * 2) != JAS_CAST(int, txtdesc->uclen * 2) ||
+	  jas_stream_write(out, txtdesc->ucdata, txtdesc->uclen * 2) != txtdesc->uclen * 2 ||
 	  jas_iccputuint16(out, txtdesc->sccode) ||
 	  jas_stream_putc(out, txtdesc->maclen) == EOF)
 		goto error;
@@ -1183,7 +1183,7 @@ static int jas_icctxt_input(jas_iccattrval_t *attrval, jas_stream_t *in,
 	txt->string = 0;
 	if (!(txt->string = jas_malloc(cnt)))
 		goto error;
-	if (jas_stream_read(in, txt->string, cnt) != (int)cnt)
+	if (jas_stream_read(in, txt->string, cnt) != cnt)
 		goto error;
 	txt->string[cnt - 1] = '\0';
 	if (strlen(txt->string) + 1 != cnt)

--- a/src/libjasper/base/jas_stream.c
+++ b/src/libjasper/base/jas_stream.c
@@ -725,6 +725,20 @@ int jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt)
 	return n;
 }
 
+unsigned jas_stream_peek(jas_stream_t *stream, void *buf, size_t cnt)
+{
+	char *bufptr = buf;
+
+	const unsigned n = jas_stream_read(stream, bufptr, cnt);
+
+	/* Put the characters read back onto the stream. */
+	for (unsigned i = n; i-- > 0;)
+		if (jas_stream_ungetc(stream, bufptr[i]) == EOF)
+			return 0;
+
+	return n;
+}
+
 /* FIXME integral type */
 int jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt)
 {

--- a/src/libjasper/base/jas_stream.c
+++ b/src/libjasper/base/jas_stream.c
@@ -213,8 +213,7 @@ jas_stream_t *jas_stream_memopen2(char *buf, size_t bufsize)
 
 	/* Since the stream data is already resident in memory, buffering
 	is not necessary. */
-	/* But... It still may be faster to use buffering anyways. */
-	jas_stream_initbuf(stream, JAS_STREAM_FULLBUF, 0, 0);
+	jas_stream_initbuf(stream, JAS_STREAM_UNBUF, 0, 0);
 
 	/* Select the operations for a memory stream. */
 	stream->ops_ = &jas_stream_memops;

--- a/src/libjasper/base/jas_stream.c
+++ b/src/libjasper/base/jas_stream.c
@@ -1059,25 +1059,25 @@ static int jas_strtoopenmode(const char *s)
 /* FIXME integral type */
 int jas_stream_copy(jas_stream_t *out, jas_stream_t *in, int n)
 {
-	int c;
 	int m;
 
 	const bool all = n < 0;
 
+	char buffer[JAS_STREAM_BUFSIZE];
+
 	m = n;
 	while (all || m > 0) {
-		if ((c = jas_stream_getc_macro(in)) == EOF) {
-			/* The next character of input could not be read. */
-			/* Return with an error if an I/O error occured
-			  (not including EOF) or if an explicit copy count
-			  was specified. */
-			return (!all || jas_stream_error(in)) ? (-1) : 0;
-		}
-		if (jas_stream_putc_macro(out, c) == EOF) {
+		int nbytes = jas_stream_read(in, buffer,
+					     JAS_MIN((size_t)m, sizeof(buffer)));
+		if (nbytes == 0)
+			return !all || jas_stream_error(in) ? -1 : 0;
+
+		if (jas_stream_write(out, buffer, nbytes) != nbytes)
 			return -1;
-		}
-		--m;
+
+		m -= nbytes;
 	}
+
 	return 0;
 }
 

--- a/src/libjasper/base/jas_stream.c
+++ b/src/libjasper/base/jas_stream.c
@@ -675,7 +675,7 @@ int jas_stream_ungetc(jas_stream_t *stream, int c)
 }
 
 /* FIXME integral type */
-int jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt)
+unsigned jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt)
 {
 	int c;
 	char *bufptr;
@@ -740,7 +740,7 @@ unsigned jas_stream_peek(jas_stream_t *stream, void *buf, size_t cnt)
 }
 
 /* FIXME integral type */
-int jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt)
+unsigned jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt)
 {
 	const char *bufptr;
 
@@ -1143,8 +1143,8 @@ int jas_stream_copy(jas_stream_t *out, jas_stream_t *in, int n)
 
 	m = n;
 	while (all || m > 0) {
-		int nbytes = jas_stream_read(in, buffer,
-					     JAS_MIN((size_t)m, sizeof(buffer)));
+		unsigned nbytes = jas_stream_read(in, buffer,
+						  JAS_MIN((size_t)m, sizeof(buffer)));
 		if (nbytes == 0)
 			return !all || jas_stream_error(in) ? -1 : 0;
 

--- a/src/libjasper/bmp/bmp_dec.c
+++ b/src/libjasper/bmp/bmp_dec.c
@@ -294,26 +294,14 @@ error:
 
 int bmp_validate(jas_stream_t *in)
 {
-	int n;
-	int i;
 	jas_uchar buf[2];
 
 	assert(JAS_STREAM_MAXPUTBACK >= 2);
 
 	/* Read the first two characters that constitute the signature. */
-	if ((n = jas_stream_read(in, (char *) buf, 2)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-	/* Put the characters read back onto the stream. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-	/* Did we read enough characters? */
-	if (n < 2) {
-		return -1;
-	}
+
 	/* Is the signature correct for the BMP format? */
 	if (buf[0] == (BMP_MAGIC & 0xff) && buf[1] == (BMP_MAGIC >> 8)) {
 		return 0;

--- a/src/libjasper/include/jasper/jas_debug.h
+++ b/src/libjasper/include/jasper/jas_debug.h
@@ -105,7 +105,7 @@ JAS_DLLEXPORT int jas_setdbglevel(int dbglevel);
 JAS_DLLEXPORT int jas_eprintf(const char *fmt, ...);
 
 /* Dump memory to a stream. */
-int jas_memdump(FILE *out, void *data, size_t len);
+int jas_memdump(FILE *out, const void *data, size_t len);
 
 /* Warn about use of deprecated functionality. */
 void jas_deprecated(const char *s);

--- a/src/libjasper/include/jasper/jas_stream.h
+++ b/src/libjasper/include/jasper/jas_stream.h
@@ -357,6 +357,11 @@ JAS_DLLEXPORT long jas_stream_setrwcount(jas_stream_t *stream, long rwcnt);
 /* Read characters from a stream into a buffer. */
 JAS_DLLEXPORT int jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt);
 
+/* Read characters from a stream into a buffer without actually
+   removing them from the stream.  Returns the number of bytes copied
+   to the given buffer, or 0 on error. */
+JAS_DLLEXPORT unsigned jas_stream_peek(jas_stream_t *stream, void *buf, size_t cnt);
+
 /* Write characters from a buffer to a stream. */
 JAS_DLLEXPORT int jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt);
 

--- a/src/libjasper/include/jasper/jas_stream.h
+++ b/src/libjasper/include/jasper/jas_stream.h
@@ -355,7 +355,7 @@ JAS_DLLEXPORT long jas_stream_setrwcount(jas_stream_t *stream, long rwcnt);
 #endif
 
 /* Read characters from a stream into a buffer. */
-JAS_DLLEXPORT int jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt);
+JAS_DLLEXPORT unsigned jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt);
 
 /* Read characters from a stream into a buffer without actually
    removing them from the stream.  Returns the number of bytes copied
@@ -363,7 +363,7 @@ JAS_DLLEXPORT int jas_stream_read(jas_stream_t *stream, void *buf, unsigned cnt)
 JAS_DLLEXPORT unsigned jas_stream_peek(jas_stream_t *stream, void *buf, size_t cnt);
 
 /* Write characters from a buffer to a stream. */
-JAS_DLLEXPORT int jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt);
+JAS_DLLEXPORT unsigned jas_stream_write(jas_stream_t *stream, const void *buf, unsigned cnt);
 
 /* Write formatted output to a stream. */
 JAS_DLLEXPORT int jas_stream_printf(jas_stream_t *stream, const char *fmt, ...);

--- a/src/libjasper/jp2/jp2_cod.c
+++ b/src/libjasper/jp2/jp2_cod.c
@@ -468,7 +468,7 @@ static int jp2_colr_getdata(jp2_box_t *box, jas_stream_t *in)
 		if (!(colr->iccp = jas_alloc2(colr->iccplen, sizeof(uint_fast8_t)))) {
 			return -1;
 		}
-		if (jas_stream_read(in, colr->iccp, colr->iccplen) != colr->iccplen) {
+		if (jas_stream_read(in, colr->iccp, colr->iccplen) != (int)colr->iccplen) {
 			return -1;
 		}
 		break;

--- a/src/libjasper/jp2/jp2_cod.c
+++ b/src/libjasper/jp2/jp2_cod.c
@@ -682,45 +682,20 @@ static int jp2_getuint8(jas_stream_t *in, uint_fast8_t *val)
 
 static int jp2_getuint16(jas_stream_t *in, uint_fast16_t *val)
 {
-	uint_fast16_t v;
-	int c;
-	if ((c = jas_stream_getc(in)) == EOF) {
+	jas_uchar buffer[2];
+	if (jas_stream_read(in, buffer, sizeof(buffer)) != sizeof(buffer))
 		return -1;
-	}
-	v = c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if (val) {
-		*val = v;
-	}
+	*val = (uint_fast16_t)buffer[0] << 8 | (uint_fast16_t)buffer[1];
 	return 0;
 }
 
 static int jp2_getuint32(jas_stream_t *in, uint_fast32_t *val)
 {
-	uint_fast32_t v;
-	int c;
-	if ((c = jas_stream_getc(in)) == EOF) {
+	jas_uchar buffer[4];
+	if (jas_stream_read(in, buffer, sizeof(buffer)) != sizeof(buffer))
 		return -1;
-	}
-	v = c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if (val) {
-		*val = v;
-	}
+	*val = (uint_fast32_t)buffer[0] << 24 | (uint_fast32_t)buffer[1] << 16
+		| (uint_fast32_t)buffer[2] << 8 | (uint_fast32_t)buffer[3];
 	return 0;
 }
 

--- a/src/libjasper/jp2/jp2_cod.c
+++ b/src/libjasper/jp2/jp2_cod.c
@@ -468,7 +468,7 @@ static int jp2_colr_getdata(jp2_box_t *box, jas_stream_t *in)
 		if (!(colr->iccp = jas_alloc2(colr->iccplen, sizeof(uint_fast8_t)))) {
 			return -1;
 		}
-		if (jas_stream_read(in, colr->iccp, colr->iccplen) != (int)colr->iccplen) {
+		if (jas_stream_read(in, colr->iccp, colr->iccplen) != colr->iccplen) {
 			return -1;
 		}
 		break;
@@ -637,8 +637,7 @@ static int jp2_colr_putdata(const jp2_box_t *box, jas_stream_t *out)
 		}
 		break;
 	case JP2_COLR_ICC:
-		if (jas_stream_write(out, colr->iccp,
-		  JAS_CAST(int, colr->iccplen)) != JAS_CAST(int, colr->iccplen))
+		if (jas_stream_write(out, colr->iccp, colr->iccplen) != colr->iccplen)
 			return -1;
 		break;
 	}

--- a/src/libjasper/jp2/jp2_cod.h
+++ b/src/libjasper/jp2/jp2_cod.h
@@ -178,7 +178,7 @@ typedef struct {
 	uint_fast8_t approx;
 	uint_fast32_t csid;
 	uint_fast8_t *iccp;
-	int iccplen;
+	size_t iccplen;
 	/* XXX - Someday we ought to add ICC profile data here. */
 } jp2_colr_t;
 

--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -470,8 +470,6 @@ error:
 int jp2_validate(jas_stream_t *in)
 {
 	unsigned char buf[JP2_VALIDATELEN];
-	int i;
-	int n;
 #if 0
 	jas_stream_t *tmpstream;
 	jp2_box_t *box;
@@ -481,22 +479,8 @@ int jp2_validate(jas_stream_t *in)
 
 	/* Read the validation data (i.e., the data used for detecting
 	  the format). */
-	if ((n = jas_stream_read(in, buf, JP2_VALIDATELEN)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-
-	/* Put the validation data back onto the stream, so that the
-	  stream position will not be changed. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-
-	/* Did we read enough data? */
-	if (n < JP2_VALIDATELEN) {
-		return -1;
-	}
 
 	/* Is the box type correct? */
 	if ((((uint_least32_t)buf[4] << 24) | ((uint_least32_t)buf[5] << 16) | ((uint_least32_t)buf[6] << 8) | (uint_least32_t)buf[7]) !=

--- a/src/libjasper/jp2/jp2_enc.c
+++ b/src/libjasper/jp2/jp2_enc.c
@@ -273,7 +273,7 @@ int jp2_encode(jas_image_t *image, jas_stream_t *out, const char *optstr)
 		}
 		jas_stream_rewind(iccstream);
 		if (jas_stream_read(iccstream, colr->iccp, colr->iccplen) !=
-		  colr->iccplen) {
+		  (int)colr->iccplen) {
 			jas_eprintf("cannot read temporary stream\n");
 			goto error;
 		}

--- a/src/libjasper/jp2/jp2_enc.c
+++ b/src/libjasper/jp2/jp2_enc.c
@@ -273,7 +273,7 @@ int jp2_encode(jas_image_t *image, jas_stream_t *out, const char *optstr)
 		}
 		jas_stream_rewind(iccstream);
 		if (jas_stream_read(iccstream, colr->iccp, colr->iccplen) !=
-		  (int)colr->iccplen) {
+		  colr->iccplen) {
 			jas_eprintf("cannot read temporary stream\n");
 			goto error;
 		}

--- a/src/libjasper/jpc/jpc_cs.c
+++ b/src/libjasper/jpc/jpc_cs.c
@@ -1628,19 +1628,10 @@ int jpc_putuint8(jas_stream_t *out, uint_fast8_t val)
 
 int jpc_getuint16(jas_stream_t *in, uint_fast16_t *val)
 {
-	uint_fast16_t v;
-	int c;
-	if ((c = jas_stream_getc(in)) == EOF) {
+	jas_uchar buffer[2];
+	if (jas_stream_read(in, buffer, sizeof(buffer)) != sizeof(buffer))
 		return -1;
-	}
-	v = c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if (val) {
-		*val = v;
-	}
+	*val = (uint_fast16_t)buffer[0] << 8 | (uint_fast16_t)buffer[1];
 	return 0;
 }
 
@@ -1655,27 +1646,11 @@ int jpc_putuint16(jas_stream_t *out, uint_fast16_t val)
 
 int jpc_getuint32(jas_stream_t *in, uint_fast32_t *val)
 {
-	uint_fast32_t v;
-	int c;
-	if ((c = jas_stream_getc(in)) == EOF) {
+	jas_uchar buffer[4];
+	if (jas_stream_read(in, buffer, sizeof(buffer)) != sizeof(buffer))
 		return -1;
-	}
-	v = c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if ((c = jas_stream_getc(in)) == EOF) {
-		return -1;
-	}
-	v = (v << 8) | c;
-	if (val) {
-		*val = v;
-	}
+	*val = (uint_fast32_t)buffer[0] << 24 | (uint_fast32_t)buffer[1] << 16
+		| (uint_fast32_t)buffer[2] << 8 | (uint_fast32_t)buffer[3];
 	return 0;
 }
 

--- a/src/libjasper/jpc/jpc_cs.c
+++ b/src/libjasper/jpc/jpc_cs.c
@@ -1259,7 +1259,7 @@ static int jpc_ppt_getparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *in
 		if (!(ppt->data = jas_malloc(ppt->len))) {
 			goto error;
 		}
-		if (jas_stream_read(in, (char *) ppt->data, ppt->len) != JAS_CAST(int, ppt->len)) {
+		if (jas_stream_read(in, (char *) ppt->data, ppt->len) != ppt->len) {
 			goto error;
 		}
 	} else {
@@ -1282,7 +1282,7 @@ static int jpc_ppt_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 	if (jpc_putuint8(out, ppt->ind)) {
 		return -1;
 	}
-	if (jas_stream_write(out, (char *) ppt->data, ppt->len) != JAS_CAST(int, ppt->len)) {
+	if (jas_stream_write(out, (char *) ppt->data, ppt->len) != ppt->len) {
 		return -1;
 	}
 	return 0;
@@ -1497,7 +1497,7 @@ static int jpc_com_getparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *in
 		if (!(com->data = jas_malloc(com->len))) {
 			return -1;
 		}
-		if (jas_stream_read(in, com->data, com->len) != JAS_CAST(int, com->len)) {
+		if (jas_stream_read(in, com->data, com->len) != com->len) {
 			return -1;
 		}
 	} else {
@@ -1516,7 +1516,7 @@ static int jpc_com_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 	if (jpc_putuint16(out, com->regid)) {
 		return -1;
 	}
-	if (jas_stream_write(out, com->data, com->len) != JAS_CAST(int, com->len)) {
+	if (jas_stream_write(out, com->data, com->len) != com->len) {
 		return -1;
 	}
 	return 0;
@@ -1568,8 +1568,7 @@ static int jpc_unk_getparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *in
 		if (!(unk->data = jas_alloc2(ms->len, sizeof(unsigned char)))) {
 			return -1;
 		}
-		if (jas_stream_read(in, (char *) unk->data, ms->len) !=
-		  JAS_CAST(int, ms->len)) {
+		if (jas_stream_read(in, (char *) unk->data, ms->len) != ms->len) {
 			jas_free(unk->data);
 			return -1;
 		}

--- a/src/libjasper/jpc/jpc_cs.c
+++ b/src/libjasper/jpc/jpc_cs.c
@@ -1709,23 +1709,13 @@ static const jpc_mstabent_t *jpc_mstab_lookup(int id)
 
 int jpc_validate(jas_stream_t *in)
 {
-	int n;
-	int i;
 	unsigned char buf[2];
 
 	assert(JAS_STREAM_MAXPUTBACK >= 2);
 
-	if ((n = jas_stream_read(in, (char *) buf, 2)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-	if (n < 2) {
-		return -1;
-	}
+
 	if (buf[0] == (JPC_MS_SOC >> 8) && buf[1] == (JPC_MS_SOC & 0xff)) {
 		return 0;
 	}

--- a/src/libjasper/jpc/jpc_dec.c
+++ b/src/libjasper/jpc/jpc_dec.c
@@ -2383,7 +2383,6 @@ static jpc_streamlist_t *jpc_ppmstabtostreams(jpc_ppxstab_t *tab)
 	uint_fast32_t datacnt;
 	uint_fast32_t tpcnt;
 	jas_stream_t *stream;
-	int n;
 
 	if (!(streams = jpc_streamlist_create())) {
 		goto error;
@@ -2426,7 +2425,7 @@ static jpc_streamlist_t *jpc_ppmstabtostreams(jpc_ppxstab_t *tab)
 				dataptr = ent->data;
 				datacnt = ent->len;
 			}
-			n = JAS_MIN(tpcnt, datacnt);
+			const size_t n = JAS_MIN(tpcnt, datacnt);
 			if (jas_stream_write(stream, dataptr, n) != n) {
 				goto error;
 			}
@@ -2458,7 +2457,7 @@ static int jpc_pptstabwrite(jas_stream_t *out, jpc_ppxstab_t *tab)
 {
 	for (unsigned i = 0; i < tab->numents; ++i) {
 		const jpc_ppxstabent_t *ent = tab->ents[i];
-		if (jas_stream_write(out, ent->data, ent->len) != JAS_CAST(int, ent->len)) {
+		if (jas_stream_write(out, ent->data, ent->len) != ent->len) {
 			return -1;
 		}
 	}

--- a/src/libjasper/jpg/jpg_val.c
+++ b/src/libjasper/jpg/jpg_val.c
@@ -79,29 +79,13 @@
 int jpg_validate(jas_stream_t *in)
 {
 	jas_uchar buf[JPG_MAGICLEN];
-	int i;
-	int n;
 
 	assert(JAS_STREAM_MAXPUTBACK >= JPG_MAGICLEN);
 
 	/* Read the validation data (i.e., the data used for detecting
 	  the format). */
-	if ((n = jas_stream_read(in, buf, JPG_MAGICLEN)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-
-	/* Put the validation data back onto the stream, so that the
-	  stream position will not be changed. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-
-	/* Did we read enough data? */
-	if (n < JPG_MAGICLEN) {
-		return -1;
-	}
 
 	/* Does this look like JPEG? */
 	if (buf[0] != (JPG_MAGIC >> 8) || buf[1] != (JPG_MAGIC & 0xff)) {

--- a/src/libjasper/mif/mif_cod.c
+++ b/src/libjasper/mif/mif_cod.c
@@ -377,29 +377,13 @@ int mif_validate(jas_stream_t *in)
 {
 	jas_uchar buf[MIF_MAGICLEN];
 	uint_fast32_t magic;
-	int i;
-	int n;
 
 	assert(JAS_STREAM_MAXPUTBACK >= MIF_MAGICLEN);
 
 	/* Read the validation data (i.e., the data used for detecting
 	  the format). */
-	if ((n = jas_stream_read(in, buf, MIF_MAGICLEN)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-
-	/* Put the validation data back onto the stream, so that the
-	  stream position will not be changed. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-
-	/* Was enough data read? */
-	if (n < MIF_MAGICLEN) {
-		return -1;
-	}
 
 	/* Compute the signature value. */
 	magic = (JAS_CAST(uint_fast32_t, buf[0]) << 24) |

--- a/src/libjasper/pgx/pgx_dec.c
+++ b/src/libjasper/pgx/pgx_dec.c
@@ -227,29 +227,13 @@ int pgx_validate(jas_stream_t *in)
 {
 	jas_uchar buf[PGX_MAGICLEN];
 	uint_fast32_t magic;
-	int i;
-	int n;
 
 	assert(JAS_STREAM_MAXPUTBACK >= PGX_MAGICLEN);
 
 	/* Read the validation data (i.e., the data used for detecting
 	  the format). */
-	if ((n = jas_stream_read(in, buf, PGX_MAGICLEN)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-
-	/* Put the validation data back onto the stream, so that the
-	  stream position will not be changed. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-
-	/* Did we read enough data? */
-	if (n < PGX_MAGICLEN) {
-		return -1;
-	}
 
 	/* Compute the signature value. */
 	magic = (buf[0] << 8) | buf[1];

--- a/src/libjasper/pnm/pnm_dec.c
+++ b/src/libjasper/pnm/pnm_dec.c
@@ -258,25 +258,13 @@ error:
 int pnm_validate(jas_stream_t *in)
 {
 	jas_uchar buf[2];
-	int i;
-	int n;
 
 	assert(JAS_STREAM_MAXPUTBACK >= 2);
 
 	/* Read the first two characters that constitute the signature. */
-	if ((n = jas_stream_read(in, buf, 2)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-	/* Put these characters back to the stream. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-	/* Did we read enough data? */
-	if (n < 2) {
-		return -1;
-	}
+
 	/* Is this the correct signature for a PNM file? */
 	if (buf[0] == 'P' && isdigit(buf[1])) {
 		return 0;

--- a/src/libjasper/ras/ras_dec.c
+++ b/src/libjasper/ras/ras_dec.c
@@ -264,30 +264,14 @@ error:
 int ras_validate(jas_stream_t *in)
 {
 	jas_uchar buf[RAS_MAGICLEN];
-	int i;
-	int n;
 	uint_fast32_t magic;
 
 	assert(JAS_STREAM_MAXPUTBACK >= RAS_MAGICLEN);
 
 	/* Read the validation data (i.e., the data used for detecting
 	  the format). */
-	if ((n = jas_stream_read(in, buf, RAS_MAGICLEN)) < 0) {
+	if (jas_stream_peek(in, buf, sizeof(buf)) != sizeof(buf))
 		return -1;
-	}
-
-	/* Put the validation data back onto the stream, so that the
-	  stream position will not be changed. */
-	for (i = n - 1; i >= 0; --i) {
-		if (jas_stream_ungetc(in, buf[i]) == EOF) {
-			return -1;
-		}
-	}
-
-	/* Did we read enough data? */
-	if (n < RAS_MAGICLEN) {
-		return -1;
-	}
 
 	magic = (JAS_CAST(uint_fast32_t, buf[0]) << 24) |
 	  (JAS_CAST(uint_fast32_t, buf[1]) << 16) |


### PR DESCRIPTION
Reduces memory usage a bit and speeds up the decoder by 5-10%.