### PR TITLE
Fix SOP marker checking

### DIFF
--- a/src/libjasper/jpc/jpc_t2dec.c
+++ b/src/libjasper/jpc/jpc_t2dec.c
@@ -195,7 +195,15 @@ static int jpc_dec_decodepkt(jpc_dec_t *dec, jas_stream_t *pkthdrstream, jas_str
 			}
 			if (jpc_ms_gettype(ms) != JPC_MS_SOP) {
 				jpc_ms_destroy(ms);
-				jas_eprintf("missing SOP marker segment\n");
+				jas_eprintf("cannot get (SOP) marker segment\n");
+				return -1;
+			}
+			unsigned int maxNsop = 65536;
+			/* checking the packet sequence number */
+			if (dec->numpkts % maxNsop != ms->parms.sop.seqno) {
+				jas_eprintf("incorrect packet sequence number %d was found, but expected %d\n",
+					ms->parms.sop.seqno, dec->numpkts % maxNsop);
+				jpc_ms_destroy(ms);
 				return -1;
 			}
 			jpc_ms_destroy(ms);


### PR DESCRIPTION
**Why**: If SOP marker segments are allowed (by setting the second LSB of Scod parameter to "1" in the COD marker segment, see A.6.1 in the spec), each packet in any given tile-part may or may not be appended with an SOP marker segment. So, the decoding process should not be stopped by missing SOP markers. However, whether or not the SOP marker segment is used, the count in the Nsop (packet sequence number) is incremented for each packet.

**How**: Added code lines to check packet sequence number when a SOP is found and to show warning message when a SOP is missing.

FYI: `Nsop` is a field which has 16 bits length. Valid range of the value of `Nsop` is from 0 to 65535. The first packet in a coded tile is assigned the value zero. For every successive packet in this coded tile, this number is incremented by one. When the maximum number is reached, the number rolls over to zero.