### PR TITLE
Hotfix to SOP marker checking

### DIFF
--- a/src/libjasper/jpc/jpc_t2dec.c
+++ b/src/libjasper/jpc/jpc_t2dec.c
@@ -200,9 +200,9 @@ static int jpc_dec_decodepkt(jpc_dec_t *dec, jas_stream_t *pkthdrstream, jas_str
 			}
 			unsigned int maxNsop = 65536;
 			/* checking the packet sequence number */
-			if (dec->numpkts % maxNsop != ms->parms.sop.seqno) {
+			if (tile->pi->pktno % maxNsop != ms->parms.sop.seqno) {
 				jas_eprintf("incorrect packet sequence number %d was found, but expected %d\n",
-					ms->parms.sop.seqno, dec->numpkts % maxNsop);
+					ms->parms.sop.seqno, tile->pi->pktno % maxNsop);
 				jpc_ms_destroy(ms);
 				return -1;
 			}


### PR DESCRIPTION
fix #233

**Why**: The commit 13390bd said "the `dec->numpkts` holds the number of packets that have been already read. Because the maximum value of `Nsop` is 65535, `dec->numpkts % 65536` is necessary to validate a `Nsop` value in a SOP marker segment.", however, this was wrong.

**How**: Instead of the `dec->numpkts`, `tile->pi->pktno` is used to validate a `Nsop` because the `Nsop` is defined as packet seqence number in a **tile**. `tile->pi->pktno` holds the packet seqence number in a certain tile.