### PR TITLE
Fix for CVE-2018-19541

### DIFF
--- a/src/libjasper/base/jas_image.c
+++ b/src/libjasper/base/jas_image.c
@@ -1040,6 +1040,7 @@ int jas_image_depalettize(jas_image_t *image, unsigned cmptno, unsigned numluten
 			if (v < 0) {
 				v = 0;
 			} else if ((unsigned)v >= numlutents) {
+				assert(numlutents > 0);
 				v = numlutents - 1;
 			}
 			jas_image_writecmptsample(image, newcmptno, i, j,

--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -372,6 +372,9 @@ jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr)
 			if (cmapent->map == JP2_CMAP_DIRECT) {
 				dec->chantocmptlut[channo] = channo;
 			} else if (cmapent->map == JP2_CMAP_PALETTE) {
+				if (!pclrd->numlutents) {
+					goto error;
+				}
 				lutents = jas_alloc2(pclrd->numlutents, sizeof(int_fast32_t));
 				if (!lutents) {
 					goto error;


### PR DESCRIPTION
The fix was not backported from jasper-maint properly.
The commit 27d5a884598e909b6e88ee8bf0c5db300a418adb (see jasper-maint/jasper#25)
`numlutens` field is only validate in the encoder,
but `jas_image_depalettize` is used only in the decoder. The decoder should validate incoming data,
otherwise specifically crafter file can crash the application.
If `numlutents` is exactly 0 `v` can too big as unsigned `-1` on line 1044