### PR TITLE
Fix for ZDI-15-529

### DIFF
--- a/src/libjasper/jpc/jpc_dec.c
+++ b/src/libjasper/jpc/jpc_dec.c
@@ -1863,6 +1863,11 @@ static int jpc_dec_cp_setfromqcx(jpc_dec_cp_t *cp, jpc_dec_ccp_t *ccp,
 	/* Eliminate compiler warnings about unused variables. */
 	(void)cp;
 
+	/* Sanity check to prevent buffer overflow */
+	if (compparms->numstepsizes > (3 * JPC_MAXRLVLS + 1)) {
+		return -1;
+	}
+
 	if ((flags & JPC_QCC) || !(ccp->flags & JPC_QCC)) {
 		ccp->flags |= flags | JPC_QSET;
 		for (bandno = 0; bandno < compparms->numstepsizes; ++bandno) {


### PR DESCRIPTION
We fixed input validation as part of the fix for [ZDI-15-529](https://www.zerodayinitiative.com/advisories/ZDI-15-529/)