### PR TITLE
Improve NEWS file

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,10 @@
 ===================
 
 * Fix ZDI-15-529
+  https://github.com/jasper-software/jasper/pull/245
 
-* Fix CVE-2018-19541
+* Fix CVE-2018-19541 in decoder
+  https://github.com/jasper-software/jasper/pull/244
 
 2.0.20 (2020-09-05)
 ===================
@@ -28,7 +30,7 @@
   https://github.com/jasper-software/jasper/issues/175
   https://github.com/jasper-maint/jasper/issues/8
 
-* Fix CVE-2018-19541
+* Fix CVE-2018-19541 in encoder
   https://github.com/jasper-software/jasper/pull/199
   https://github.com/jasper-maint/jasper/issues/6
 

--- a/NEWS
+++ b/NEWS
@@ -1,23 +1,23 @@
 2.0.21 (2020-09-20)
 ===================
 
-* fixed ZDI-15-529
+* Fix ZDI-15-529
 
-* fixed CVE-2018-19541
+* Fix CVE-2018-19541
 
 2.0.20 (2020-09-05)
 ===================
 
-* fixed several ISO/IEC 15444-4 conformance bugs
+* Fix several ISO/IEC 15444-4 conformance bugs
 
-* fixed new variant of CVE-2016-9398
+* Fix new variant of CVE-2016-9398
 
-* disabled the MIF codec by default for security reasons (but it is still
+* Disable the MIF codec by default for security reasons (but it is still
   included in the library);
   in a future release, the MIF codec may also be excluded from the
   library by default
 
-* added documentation for the I/O streams library API
+* Add documentation for the I/O streams library API
 
 2.0.19 (2020-07-11)
 ===================


### PR DESCRIPTION
Capitalize first letter.
Use present tense.

Like it is done in the first entry.
Let's stay consistent.

Let's link the corresponding issues for reference.
In the case where the issue is actually directly reported in a PR with a
fix, use that instead.

Clarify about CVE-2018-19541 decoder/encoder, otherwise users might be
confused why we claim to have it fixed in 2.0.20 already.