### PR TITLE
Fix for GLUT-related build issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,6 @@ include(CheckCSourceCompiles)
 include(CTest)
 include(Sanitizers)
 
-include(JasOpenGL)
-
 cmake_policy(SET CMP0012 NEW)
 
 ################################################################################
@@ -204,6 +202,8 @@ endif()
 ################################################################################
 # Perform plaform checks.
 ################################################################################
+
+include(JasOpenGL)
 
 find_program(BASH_PROGRAM bash)
 


### PR DESCRIPTION
Moved the point at which the JasPer OpenGL CMake module is included in the top-level CMakeLists.txt file so that the main JasPer config header is generated correctly and all of the initialization required for this module is performed prior to its inclusion.