### PR TITLE
Avoid maxrlvls more than upper bound to cause heap-buffer-overflow

### DIFF
--- a/src/libjasper/jpc/jpc_enc.c
+++ b/src/libjasper/jpc/jpc_enc.c
@@ -509,6 +509,10 @@ static jpc_enc_cp_t *cp_create(const char *optstr, jas_image_t *image)
 			break;
 		case OPT_MAXRLVLS:
 			tccp->maxrlvls = atoi(jas_tvparser_getval(tvp));
+			if(tccp->maxrlvls > JPC_MAXRLVLS) {
+				jas_eprintf("invalid number of resolution levels upper than %d\n",JPC_MAXRLVLS);
+				goto error;
+			}
 			break;
 		case OPT_SOP:
 			cp->tcp.csty |= JPC_COD_SOP;


### PR DESCRIPTION
Check maxrlvls to avoid more than the upper bound.