### PR TITLE
Fix check for overflow builtins

### DIFF
--- a/src/libjasper/include/jasper/jas_math.h
+++ b/src/libjasper/include/jasper/jas_math.h
@@ -209,6 +209,10 @@ inline static int_fast32_t jas_fast32_asl(int_fast32_t x, unsigned n)
 #pragma GCC diagnostic pop
 #endif
 
+#ifndef __has_builtin
+#  define __has_builtin(x) 0
+#endif
+
 /******************************************************************************\
 * Safe integer arithmetic (i.e., with overflow checking).
 \******************************************************************************/
@@ -216,7 +220,7 @@ inline static int_fast32_t jas_fast32_asl(int_fast32_t x, unsigned n)
 /* Compute the product of two size_t integers with overflow checking. */
 inline static bool jas_safe_size_mul(size_t x, size_t y, size_t *result)
 {
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+#if __has_builtin(__builtin_mul_overflow) || (defined(__GNUC__) && __GNUC__ > 5)
 	size_t result_buffer;
 	if (!result)
 		result = &result_buffer;
@@ -252,7 +256,7 @@ inline static bool jas_safe_size_mul3(size_t a, size_t b, size_t c,
 /* Compute the sum of two size_t integers with overflow checking. */
 inline static bool jas_safe_size_add(size_t x, size_t y, size_t *result)
 {
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+#if __has_builtin(__builtin_add_overflow) || (defined(__GNUC__) && __GNUC__ > 5)
 	size_t result_buffer;
 	if (!result)
 		result = &result_buffer;
@@ -271,7 +275,7 @@ inline static bool jas_safe_size_add(size_t x, size_t y, size_t *result)
 /* Compute the difference of two size_t integers with overflow checking. */
 inline static bool jas_safe_size_sub(size_t x, size_t y, size_t *result)
 {
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+#if __has_builtin(__builtin_sub_overflow) || (defined(__GNUC__) && __GNUC__ > 5)
 	size_t result_buffer;
 	if (!result)
 		result = &result_buffer;
@@ -291,7 +295,7 @@ inline static bool jas_safe_size_sub(size_t x, size_t y, size_t *result)
 inline static bool jas_safe_intfast32_mul(int_fast32_t x, int_fast32_t y,
   int_fast32_t *result)
 {
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+#if __has_builtin(__builtin_mul_overflow) || (defined(__GNUC__) && __GNUC__ > 5)
 	int_fast32_t result_buffer;
 	if (!result)
 		result = &result_buffer;
@@ -350,7 +354,7 @@ inline static bool jas_safe_intfast32_mul3(int_fast32_t a, int_fast32_t b,
 inline static bool jas_safe_intfast32_add(int_fast32_t x, int_fast32_t y,
   int_fast32_t *result)
 {
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+#if __has_builtin(__builtin_add_overflow) || (defined(__GNUC__) && __GNUC__ > 5)
 	int_fast32_t result_buffer;
 	if (!result)
 		result = &result_buffer;


### PR DESCRIPTION
Not all versions of clang have these builtins, so use clang's
`__has_builtin` macro to check that they are available before using.