### PR TITLE
Use `__builtin_unreachable()` only with GCC 4.5+

### DIFF
--- a/src/libjasper/include/jasper/jas_compiler.h
+++ b/src/libjasper/include/jasper/jas_compiler.h
@@ -77,7 +77,11 @@
 #define JAS_ATTRIBUTE_CONST __attribute__((const))
 #define JAS_ATTRIBUTE_PURE __attribute__((pure))
 #define JAS_FORCE_INLINE inline __attribute__((always_inline))
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define JAS_UNREACHABLE() __builtin_unreachable()
+#else
+#define JAS_UNREACHABLE()
+#endif
 #define JAS_LIKELY(x) __builtin_expect (!!(x), 1)
 #define JAS_UNLIKELY(x) __builtin_expect (!!(x), 0)
 #else


### PR DESCRIPTION
GCC 4.2 fails to compile Jasper 2.0.32 as described here: https://trac.macports.org/ticket/63300

`__builtin_unreachable()` was added in GCC 4.5. Add some macro logic to address this.