### PR TITLE
Fix value in jas_safeui64_div

### DIFF
--- a/src/libjasper/include/jasper/jas_math.h
+++ b/src/libjasper/include/jasper/jas_math.h
@@ -469,7 +469,7 @@ jas_safeui64_t jas_safeui64_div(jas_safeui64_t x, jas_safeui64_t y)
 	jas_safeui64_t result;
 	if (x.valid && y.valid && y.value) {
 		result.valid = true;
-		result.value = x.value / y.valid;
+		result.value = x.value / y.value;
 	} else {
 		result.valid = false;
 		result.value = 0;


### PR DESCRIPTION
y.valid was used where we wanted y.value.

It got introduced with commit def49688. So JasPer versions affected are: 3.0.0 until 3.0.3.

Fix https://github.com/jasper-software/jasper/issues/323