### PR TITLE
add JAS_DEPRECATED macro to jas_{init,cleanup}

### DIFF
--- a/src/libjasper/include/jasper/jas_init.h
+++ b/src/libjasper/include/jasper/jas_init.h
@@ -306,6 +306,7 @@ on the same thread.
 @deprecated
 This function is deprecated.
 */
+JAS_DEPRECATED
 JAS_EXPORT
 int jas_init(void);
 
@@ -323,6 +324,7 @@ on the same thread.
 @deprecated
 This function is deprecated.
 */
+JAS_DEPRECATED
 JAS_EXPORT
 void jas_cleanup(void);
 


### PR DESCRIPTION
they are deprecated, as stated in the documentation, but aren't denoted by the macro `JAS_DEPRECATED`