### PR TITLE
pkgconfig: Add Cflags.private field for static linking

### DIFF
--- a/build/jasper.pc.in
+++ b/build/jasper.pc.in
@@ -8,3 +8,4 @@ Version: @JAS_VERSION@
 
 Libs: -L${libdir} -ljasper
 Cflags: -I${includedir}/jasper -I${includedir}
+Cflags.private: -DLIBJASPER_STATIC_DEFINE


### PR DESCRIPTION
This defines LIBJASPER_STATIC_DEFINE when static linking is expected.
The Cflags.private field depends on pkgconf rather than pkg-config.
Without this change, linker finds exported APIs with dllimport and
it produces the error:

```
ld.exe: test_1.c:(.text+0x2b): undefined reference to `__imp_jas_get_total_mem_size'
ld.exe: test_1.c:(.text+0x4b): undefined reference to `__imp_jas_optarg'
```

and more.

Result of this change:

* Before:
$ pkgconf -cflags -static jasper
-IF:/msys64/ucrt64/include/jasper -IF:/msys64/ucrt64/include

* After:
$ pkgconf -cflags -static jasper
-IF:/msys64/ucrt64/include/jasper -IF:/msys64/ucrt64/include -DLIBJASPER_STATIC_DEFINE