### PR TITLE
pkgconfig: Add Requires.private field for static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,9 @@ if(JAS_INCLUDE_JP2_CODEC AND NOT JAS_INCLUDE_JPC_CODEC)
 	  "The JPC codec must be included in order to include the JP2 codec.")
 endif()
 
+# Prepare variable for pkgconfig file
+set(JAS_PKGCONFIG_REQUIRES)
+
 ################################################################################
 # Configure threading support
 ################################################################################
@@ -737,6 +740,7 @@ if(JAS_ENABLE_LIBJPEG)
 		if(JAS_HAVE_JPEGLIB_H)
 			set(JAS_HAVE_LIBJPEG 1)
 			set(JAS_LIBJPEG_TARGET JPEG::JPEG)
+			list(APPEND JAS_PKGCONFIG_REQUIRES libjpeg)
 		else()
 			message(WARNING "The header file jpeglib.h is missing.")
 			message(WARNING "Disabling LIBJPEG.")
@@ -760,6 +764,7 @@ if(JAS_ENABLE_LIBHEIF)
 	if(HEIF_LIBRARY AND JAS_HAVE_HEIF_H)
 		set(JAS_HAVE_LIBHEIF 1)
 		set(HEIF_LIBRARIES "${HEIF_LIBRARY}")
+		list(APPEND JAS_PKGCONFIG_REQUIRES libheif)
 	endif()
 endif()
 if(NOT JAS_HAVE_LIBHEIF)
@@ -818,6 +823,7 @@ endif()
 
 # The package configuation (pc) file should be installed in
 # ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig.
+string(JOIN " " JAS_PKGCONFIG_REQUIRES ${JAS_PKGCONFIG_REQUIRES})
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/build/jasper.pc.in"
   "${CMAKE_CURRENT_BINARY_DIR}/build/jasper.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/build/jasper.pc"

--- a/build/jasper.pc.in
+++ b/build/jasper.pc.in
@@ -7,5 +7,6 @@ Description: Image Processing/Coding Tool Kit with JPEG-2000 Support
 Version: @JAS_VERSION@
 
 Libs: -L${libdir} -ljasper
+Requires.private: @JAS_PKGCONFIG_REQUIRES@
 Cflags: -I${includedir}/jasper -I${includedir}
 Cflags.private: -DLIBJASPER_STATIC_DEFINE


### PR DESCRIPTION
Requires.private field is required to link dependent libraries while static linking. For example, here libjpeg and libheif. `pkgconf -libs -static` command will show the dependent libraries. This helps to manage the dependent libraries automatically in build system without adding them explicitly while static linking. More information about this feature can be found here https://people.freedesktop.org/~dbn/pkg-config-guide.html