### PR TITLE
[hotfix] Do not enforce rpath when building shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,21 +792,6 @@ if(JAS_ENABLE_SHARED)
 	# when building, don't use the install RPATH already
 	# (but later on when installing)
 	set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
-	# add the automatically determined parts of the RPATH
-	# which point to directories outside the build tree to the install RPATH
-	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-	# The RPATH to be used when installing, but only if it's not a
-	# system directory
-	list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
-	  "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-	if(isSystemDir EQUAL -1)
-	   set(CMAKE_INSTALL_RPATH
-		  "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-	endif()
 endif()
 
 ################################################################################


### PR DESCRIPTION
Greetings!

Conan has been packaged Jasper for a time and one thing which we always need to do is disabling the rpath configuration hardcoded in the CMakeLists.txt. As side-effect, once the library is packaged, its rpath will point to where it was created, in that case, the CI environment. It's just example, but it would occur for anyone who build Jasper locally and tries to distribute.

Those kind of configuration can be manually configured by a CMake toolchain file apart or by command line definitions. 

/cc @SpaceIm 