### PR TITLE
doc/CMakeLists.txt: fix prallel build of api docs and pdf manual

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -44,7 +44,7 @@ if(DOXYGEN_FOUND)
 		add_custom_command(OUTPUT "latex/refman.pdf"
 		  COMMAND "${PDFLATEX_COMPILER}" refman.tex
 		  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/latex"
-		  DEPENDS "latex/index.tex"
+		  DEPENDS "doc"
 		)
 
 		add_custom_target(manual_pdf ALL


### PR DESCRIPTION
according to cmake docs DEPENDS in add_custom_command with file being output of other custom command:

> If any dependency is an OUTPUT of another custom command in the same
> directory (CMakeLists.txt file), CMake automatically brings the other
> custom command into the target in which this command is built.

this means "manual_pdf" target will not wait for previous doxygen invocation but will trigger its own. in case of parallel build two doxygen invocations with same input parameters might overwrite each other's output resulting in broken files. it could be verified with just grepping cmake output:

```console
$ grep -r 'doxygen Doxyfile' builddir/doc
builddir/doc/CMakeFiles/doc.dir/build.make:	cd /home/users/builder/rpm/BUILD/jasper-3.0.6/builddir/doc && /usr/bin/doxygen Doxyfile
builddir/doc/CMakeFiles/manual_pdf.dir/build.make:	cd /home/users/builder/rpm/BUILD/jasper-3.0.6/builddir/doc && /usr/bin/doxygen Doxyfile
```

instead of putting dependency on "latex/index.tex" file, use "doc" target as dependency resulting in ordering "doc" before "manual_pdf" and single doxygen invocation.