### PR TITLE
Add <stdatomic.h> check to JAS_TRY_COMPILE_C11_THREADS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,6 +592,7 @@ set(JAS_HAVE_WIN32_THREADS FALSE)
 if(JAS_ENABLE_MULTITHREADING_SUPPORT)
 	check_c_source_compiles("
 	#include <threads.h>
+	#include <stdatomic.h>
 	int main() {
 		thrd_t thread;
 		mtx_t mutex;


### PR DESCRIPTION
In https://github.com/jasper-software/jasper/blob/b867d1adb2e6423c260407338bdc8d698330764e/src/libjasper/include/jasper/jas_thread.h#L87-L89 , JAS_THREADS_C11 assumes that both <threads.h> and <stdatomic.h> are available, but here, <stdatomic.h> is not checked. This causes builds with MSVC to fail with spew like:

```console
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(36): error C2061: syntax error: identifier 'atomic_bool'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(36): error C2059: syntax error: ';'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(37): error C2061: syntax error: identifier 'atomic_char'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(37): error C2059: syntax error: ';'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(38): error C2061: syntax error: identifier 'atomic_schar'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(38): error C2059: syntax error: ';'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(39): error C2061: syntax error: identifier 'atomic_uchar'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(39): error C2059: syntax error: ';'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(40): error C2061: syntax error: identifier 'atomic_short'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(40): error C2059: syntax error: ';'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(41): error C2061: syntax error: identifier 'atomic_ushort'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vcruntime_c11_stdatomic.h(41): error C2059: syntax error: ';'
```

(MSVC 17.4 supports C atomics but it's behind a bunch of 'enable experimental things' switches right now, so including `<stdatomic.h>` without checking `STDC_NO_ATOMICS` fails like this)

Thanks to Charlie Barto and Casey Carter for helping me debug this.