### PR TITLE
Silence UBSan implicit-conversion reports in src/libjasper/base/jas_stream.c

### DIFF
--- a/src/libjasper/base/jas_stream.c
+++ b/src/libjasper/base/jas_stream.c
@@ -695,7 +695,7 @@ size_t jas_stream_read(jas_stream_t *stream, void *buf, size_t cnt)
 		if ((c = jas_stream_getc(stream)) == EOF) {
 			return n;
 		}
-		*bufptr++ = c;
+		*bufptr++ = (char)c;
 		++n;
 	}
 


### PR DESCRIPTION
Hi,
This PR silences UBSan implicit-conversion reports in `src/libjasper/base/jas_stream.c` by making the byte stores explicit (casting `int` to `char`). 

### stack trace

```text
/root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:698:15: runtime error: implicit conversion from type 'int' of value 128 (32-bit, signed) to type 'char' changed the value to -128 (8-bit, signed)
    #0 0x53fcc6 in jas_stream_read /root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:698:15
    #1 0x53ff1f in jas_stream_peek /root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:710:19
    #2 0x68084d in pnm_validate /root/build/jasper-4.2.8/src/libjasper/pnm/pnm_dec.c:270:6
    #3 0x512ef4 in jas_image_getfmt /root/build/jasper-4.2.8/src/libjasper/base/jas_image.c:897:9
    #4 0x4cbde5 in main /root/build/jasper-4.2.8/src/app/jasper.c:312:25

/root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:648:18: runtime error: implicit conversion from type 'int' of value -128 (32-bit, signed) to type 'unsigned char' changed the value to 128 (8-bit, unsigned)
    #0 0x53f338 in jas_stream_ungetc /root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:648:18
    #1 0x540039 in jas_stream_peek /root/build/jasper-4.2.8/src/libjasper/base/jas_stream.c:714:7
    #2 0x68084d in pnm_validate /root/build/jasper-4.2.8/src/libjasper/pnm/pnm_dec.c:270:6
    #3 0x512ef4 in jas_image_getfmt /root/build/jasper-4.2.8/src/libjasper/base/jas_image.c:897:9
    #4 0x4cbde5 in main /root/build/jasper-4.2.8/src/app/jasper.c:312:25
```

Is this kind of change acceptable?
Thanks!